### PR TITLE
Add custom k8s path input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ edit-kustomizations:
 
 commit-kustomizations:
 	git reset
-	find ./k8s -type f -name kustomization.yaml -exec git add {} \+
+	find $(K8S_PATH) -type f -name kustomization.yaml -exec git add {} \+
 	printf "chore(k8s): update images to version $(IMAGE_TAG)\n\n$$(git log --format=%B -n1 HEAD)" | git commit -F -
 	git push --set-upstream "$$(git remote show)" "$$(git rev-parse --abbrev-ref HEAD)" || echo "Skipping commit..."
 .PHONY: commit-kustomizations

--- a/action.yaml
+++ b/action.yaml
@@ -12,12 +12,16 @@ inputs:
     description: Custom Image Tag
     required: false
     default: commit-sha
+  path:
+    description: Custom k8s path
+    required: false
+    default: ./k8s
 runs:
   using: composite
   steps:
     - name: Enforce Manifests .yaml Extension
       shell: bash
-      run: find ./k8s/overlays/*/kustomization.yml && echo 'This is an intentional error. K8s manifests extension must be ".yaml".' && exit 1 || echo 'Everything good to go!'
+      run: find ${{ inputs.path }}/overlays/*/kustomization.yml && echo 'This is an intentional error. K8s manifests extension must be ".yaml".' && exit 1 || echo 'Everything good to go!'
     - name: Set Kustomization Image Tags
       shell: bash
       run: |
@@ -31,6 +35,7 @@ runs:
         then
           export IMAGES="${IMAGE_REPOS}"
         fi
+        export K8S_PATH="${{ inputs.path }}"
 
         make -Bf ${{ github.action_path }}/Makefile OVERLAY="global-product" edit-kustomizations
         make -Bf ${{ github.action_path }}/Makefile OVERLAY="integration" edit-kustomizations

--- a/kustomize-set-image-tags.sh
+++ b/kustomize-set-image-tags.sh
@@ -11,12 +11,12 @@ split_image() {
     fi
 }
 
-if [[ ! -d "./k8s/overlays/${OVERLAY}" ]]
+if [[ ! -d "${K8S_PATH}/overlays/${OVERLAY}" ]]
 then
     exit 0
 fi
 
-cd ./k8s/overlays/${OVERLAY}
+cd ${K8S_PATH}/overlays/${OVERLAY}
 
 for IMAGE in ${IMAGES}
 do


### PR DESCRIPTION
This PR extends the plugin to support a custom k8s path and may support entrypoint-service new proposed directory structure separating product from fortknox overlays, as suggested in inloco/entrypoint-service#171. In summary, this new proposed structure defines the overlays at `./k8s/fortknox` and `./k8s/product` paths. 